### PR TITLE
Use Supervisord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM nginx:1.9
 MAINTAINER Elie Charra <elie.charra [at] kitpages.fr>
 
 # Install wget and install/updates certificates
-RUN apt-get update \
- && apt-get install -y -q --no-install-recommends \
+RUN apt-get -qq update \
+ && apt-get install -y -qq --no-install-recommends \
     ca-certificates \
+    supervisor \
     wget \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
@@ -13,16 +14,13 @@ RUN apt-get update \
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
-# Install Forego
-RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
- && chmod u+x /usr/local/bin/forego
-
 ENV DOCKER_GEN_VERSION 0.4.2
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && rm /docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
+COPY config/supervisord/conf.d /etc/supervisor/conf.d
 COPY . /app/
 WORKDIR /app/
 
@@ -31,4 +29,4 @@ ENV DOCKER_HOST unix:///tmp/docker.sock
 VOLUME ["/etc/nginx/certs"]
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["forego", "start", "-r"]
+CMD ["/usr/bin/supervisord", "-n"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-nginx: nginx
-dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf

--- a/config/supervisord/conf.d/dockergen.conf
+++ b/config/supervisord/conf.d/dockergen.conf
@@ -1,0 +1,6 @@
+[program:docker-gen]
+command=/usr/local/bin/docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/config/supervisord/conf.d/nginx.conf
+++ b/config/supervisord/conf.d/nginx.conf
@@ -1,0 +1,2 @@
+[program:nginx]
+command=/usr/sbin/nginx

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,9 +14,4 @@ if [[ $DOCKER_HOST == unix://* ]]; then
 	fi
 fi
 
-# If the user has run the default command and the socket doesn't exist, fail
-if [ "$socketMissing" = 1 -a "$1" = forego -a "$2" = start -a "$3" = '-r' ]; then
-	exit 1
-fi
-
 exec "$@"


### PR DESCRIPTION
Forego output ascii color codes and there is no option to disable this behaviour. (https://github.com/ddollar/forego/issues/68)

So let's use supervisord instead.
